### PR TITLE
修复表格等浮动体内的字体 Fix #18

### DIFF
--- a/.github/workflows/verify-compile-pr.yml
+++ b/.github/workflows/verify-compile-pr.yml
@@ -19,4 +19,4 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: PDF
-          path: public-test/thuthesis-example*.pdf
+          path: public-test/sustechthesis-example*.pdf

--- a/.github/workflows/verify-compile.yml
+++ b/.github/workflows/verify-compile.yml
@@ -20,7 +20,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           name: PDF
-          path: public-test/thuthesis-example*.pdf
+          path: public-test/sustechthesis-example*.pdf
 
       - name: Deploy PDF to latest branch
         uses: peaceiris/actions-gh-pages@v3

--- a/.gitignore
+++ b/.gitignore
@@ -33,5 +33,5 @@
 *.xdv
 *-converted-to.*
 
-thuthesis-example.pdf
+sustechthesis-example.pdf
 public*/

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
-# Makefile for ThuThesis
+# Makefile for sustechthesis
 
 PACKAGE = thuthesis
-THESIS  = thuthesis-example
+THESIS  = sustechthesis-example
 
 
 LATEXMK = latexmk

--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ SUSTech 镜像站（GitHub Releases 的镜像）: https://mirrors.sustech.edu.cn
 * `make thesis`     生成论文；
 * `make viewthesis` 生成论文，编译完成开启预览；
 * `make all`        生成论文，与 `make thesis` 等效；
-* `make clean`      删除示例文件的中间文件（不含 thuthesis-example.pdf）；
-* `make cleanall`   删除示例文件的中间文件和 thuthesis-example.pdf；
+* `make clean`      删除示例文件的中间文件（不含 sustechthesis-example.pdf）；
+* `make cleanall`   删除示例文件的中间文件和 sustechthesis-example.pdf；
 * `make distclean`  删除示例文件和模板的所有中间文件和 PDF；
 * `make wordcount`  论文字数统计。
 
@@ -41,7 +41,7 @@ SUSTech 镜像站（GitHub Releases 的镜像）: https://mirrors.sustech.edu.cn
 
 ### 编译前的建议
 
-1. 在撰写论文时，我们不推荐使用原有的 `thuthesis-example.tex` 这一名称。建议将其复制一份，改为其他的名字(如 `thesis.tex` 或者 `main.tex`)。需要注意，如果使用了来 自 `data` 目录中的 `tex` 文件，则重命名主文件后，其顶端的 `!TeX root` 选项也需要相应修改。
+1. 在撰写论文时，我们不推荐使用原有的 `sustechthesis-example.tex` 这一名称。建议将其复制一份，改为其他的名字(如 `thesis.tex` 或者 `main.tex`)。需要注意，如果使用了来 自 `data` 目录中的 `tex` 文件，则重命名主文件后，其顶端的 `!TeX root` 选项也需要相应修改。
 2. 需要注意，如果更改了主文件的名称，则需要修改 `Makefile` 顶端的 `THESIS` 变量定义；或修改 `build.bat` 和 `clean.bat` 中 `latexmk` 命令后的参数。
 3. ⚠️ 提交最终正式版本时，建议在 Windows 下本地编译且设置 `fontset` 参数 为 `windows`，以保证字体正确。
 
@@ -49,7 +49,7 @@ SUSTech 镜像站（GitHub Releases 的镜像）: https://mirrors.sustech.edu.cn
 
 ### 文档内容
 * `thusetup.tex` 示例文档基本配置（论文标题、作者等元数据）
-* `thuthesis-example.tex` 示例文档主文件
+* `sustechthesis-example.tex` 示例文档主文件
 * `data/` 示例文档章节具体内容
 * `figures/` 示例文档图片路径
 * `ref/` 示例文档参考文献目录

--- a/build.bat
+++ b/build.bat
@@ -1,1 +1,1 @@
-latexmk thuthesis-example
+latexmk sustechthesis-example

--- a/clean.bat
+++ b/clean.bat
@@ -1,2 +1,2 @@
-latexmk -c thuthesis-example
+latexmk -c sustechthesis-example
 del /Q *~ main-survey.* main-translation.* _markdown_thuthesis* thuthesis.markdown.*

--- a/data/abstract.tex
+++ b/data/abstract.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 % 中英文摘要和关键字
 

--- a/data/acknowledgements.tex
+++ b/data/acknowledgements.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \begin{acknowledgements}
   衷心感谢导师×××教授和物理系××副教授对本人的精心指导。他们的言传身教将使我终生受益。

--- a/data/chap01.tex
+++ b/data/chap01.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \chapter{论文主要部分的写法}
 

--- a/data/chap02.tex
+++ b/data/chap02.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \chapter{图表示例}
 

--- a/data/chap03.tex
+++ b/data/chap03.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \chapter{数学符号和公式}
 

--- a/data/chap04.tex
+++ b/data/chap04.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \chapter{引用文献的标注}
 

--- a/data/committee.tex
+++ b/data/committee.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 % 填写说明：
 % 1、各类名单按实际人数逐行填写，可增加或删除行，不留空行。

--- a/data/conclusion.tex
+++ b/data/conclusion.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 % 中文使用{结\quad 论}（\quad 为空格不可删除），英文使用{CONCLUSION}作为章节标题。
 

--- a/data/denotation.tex
+++ b/data/denotation.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \begin{denotation}[3cm]
   \item[PI] 聚酰亚胺

--- a/data/resume.tex
+++ b/data/resume.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \begin{resume}
 

--- a/data/statement.tex
+++ b/data/statement.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \newcommand{\authorsign}{
   \begin{table}

--- a/data/statement.tex
+++ b/data/statement.tex
@@ -4,7 +4,7 @@
   \begin{table}
     \centering
     \normalsize
-    \vspace{12bp}
+    \vspace{1em}
     \begin{tabular}{llll}
     作者签名： & \hspace{4cm} & 日期： &  \hspace{4cm}
     \end{tabular}
@@ -14,7 +14,7 @@
   \begin{table}
     \centering
     \normalsize
-    \vspace{12bp}
+    \renewcommand\arraystretch{2}%
     \begin{tabular}{llll}
     作者签名： & \hspace{4cm} & 日期： &  \hspace{4cm}\\
     指导教师签名： & \hspace{4cm} & 日期： &  \hspace{4cm}
@@ -23,19 +23,18 @@
 }
 
 \begin{statementcopyright}
+  \vspace{2em}
   \section*{南方科技大学学位论文原创性声明}
   \vspace{1em}
 
-  \begin{spacing}{1.25}
     本人郑重声明：所提交的学位论文是本人在导师指导下独立进行研究工作所取得的成果。除了特别加以标注和致谢的内容外，论文中不包含他人已发表或撰写过的研究成果。对本人的研究做出重要贡献的个人和集体，均已在文中作了明确的说明。本声明的法律结果由本人承担。
-  \end{spacing}
 
   \authorsign
 
+  \vspace{1em}
   \section*{南方科技大学学位论文使用授权书}
   \vspace{1em}
 
-  \begin{spacing}{1.25}
     本人完全了解南方科技大学有关收集、保留、使用学位论文的规定，即：
 
     \begin{enumerate}[wide]
@@ -48,7 +47,6 @@
         \end{enumerate}
       \item 保密的学位论文在解密后适用本授权书。
     \end{enumerate}
-  \end{spacing}
 
   \authorsupervisorsign
 

--- a/data/statement_en.tex
+++ b/data/statement_en.tex
@@ -1,4 +1,4 @@
-% !TeX root = ../thuthesis-example.tex
+% !TeX root = ../sustechthesis-example.tex
 
 \newcommand{\authorsign}{
   \begin{table}

--- a/sustech-setup.tex
+++ b/sustech-setup.tex
@@ -5,7 +5,7 @@
 \thusetup{
   %******************************
   % 注意：
-  %   1. 配置里面不要出现空行
+  %   1. 配置里面不要出现**空行**
   %   2. 不需要的配置信息可以删除
   %   3. 建议先阅读文档中所有关于选项的说明
   %******************************
@@ -17,11 +17,12 @@
   %
   % 标题
   %   可使用“\\”命令手动控制换行
-  %   如果需要使用副标题，自行添加 “\\{\Large 可选的副标题}” 或者 “\\{\Large optional subtitle}”，
-  %   如不需要，直接删除上述引号内的部分即可（\color{gray} 仅作展示用，使用时请删去）。
+  %   如果需要使用副标题，取消 subtitle 和 subtitle* 的注释即可（\color{gray} 仅作展示用，使用时请删去）。
   %
   title  = {南方科技大学学位论文 \LaTeX{} 模板 (Support English) 使用示例文档 v\version},
   title* = {An Introduction to \LaTeX{} Thesis Template of Southern University of Science and Technology v\version},
+  % subtitle = {\color{gray} 可选的副标题可选的副标题可选的副标题可选的副标题可选的副标题可选的副标题},
+  % subtitle* = {\color{gray} optional subtitle optional subtitle optional subtitle optional subtitle optional subtitle optional subtitle},
   %
   % 学位
   %   1. 学术型

--- a/sustech-setup.tex
+++ b/sustech-setup.tex
@@ -127,7 +127,6 @@
 % hyperref 宏包在最后调用
 \usepackage{hyperref}
 \usepackage{ragged2e}
-\usepackage{setspace}
 
 % 固定宽度的表格。放在 hyperref 之前的话，tabularx 里的 footnote 显示不出来。
 \usepackage{tabularx}

--- a/sustech-setup.tex
+++ b/sustech-setup.tex
@@ -20,8 +20,8 @@
   %   如果需要使用副标题，自行添加 “\\{\Large 可选的副标题}” 或者 “\\{\Large optional subtitle}”，
   %   如不需要，直接删除上述引号内的部分即可（\color{gray} 仅作展示用，使用时请删去）。
   %
-  title  = {南方科技大学学位论文 \LaTeX{} 模板 (Support English) 使用示例文档 v\version \\{\color{gray} \Large 可选的副标题可选的副标题可选的副标题可选的副标题可选的副标题可选的副标题}},
-  title* = {An Introduction to \LaTeX{} Thesis Template of Southern University of Science and Technology v\version \\{\color{gray} \Large optional subtitle optional subtitle optional subtitle optional subtitle optional subtitle optional subtitle}},
+  title  = {南方科技大学学位论文 \LaTeX{} 模板 (Support English) 使用示例文档 v\version},
+  title* = {An Introduction to \LaTeX{} Thesis Template of Southern University of Science and Technology v\version},
   %
   % 学位
   %   1. 学术型

--- a/sustech-setup.tex
+++ b/sustech-setup.tex
@@ -1,4 +1,4 @@
-% !TeX root = ./thuthesis-example.tex
+% !TeX root = ./sustechthesis-example.tex
 
 % 论文基本信息配置
 

--- a/sustechthesis-example.tex
+++ b/sustechthesis-example.tex
@@ -2,7 +2,7 @@
 % !TeX program = xelatex
 % !TeX spellcheck = en_US
 
-\documentclass[degree=master,language=english]{thuthesis}
+\documentclass[degree=master,language=chinese]{thuthesis}
   % 学位 degree:
   %   master （默认） | doctor
   % 语言 language:
@@ -10,7 +10,7 @@
 
 
 % 论文基本配置，加载宏包等全局配置
-\input{thusetup}
+\input{sustech-setup}
 
 
 \begin{document}
@@ -60,8 +60,8 @@
 \input{data/acknowledgements}
 
 % 南方科技大学学位论文原创性声明和使用授权说明
-% \input{data/statement} % 中文声明
-\input{data/statement_en} % 英文声明
+\input{data/statement} % 中文声明
+% \input{data/statement_en} % 英文声明
 
 % 个人简历、在学期间完成的相关学术成果
 \input{data/resume}

--- a/test/sustechthesis-example-cn.tex
+++ b/test/sustechthesis-example-cn.tex
@@ -10,7 +10,7 @@
 
 
 % 论文基本配置，加载宏包等全局配置
-\input{thusetup}
+\input{sustech-setup}
 
 
 \begin{document}

--- a/test/sustechthesis-example-en.tex
+++ b/test/sustechthesis-example-en.tex
@@ -2,7 +2,7 @@
 % !TeX program = xelatex
 % !TeX spellcheck = en_US
 
-\documentclass[degree=master,language=chinese]{thuthesis}
+\documentclass[degree=master,language=english]{thuthesis}
   % 学位 degree:
   %   master （默认） | doctor
   % 语言 language:
@@ -10,7 +10,7 @@
 
 
 % 论文基本配置，加载宏包等全局配置
-\input{thusetup}
+\input{sustech-setup}
 
 
 \begin{document}
@@ -60,8 +60,8 @@
 \input{data/acknowledgements}
 
 % 南方科技大学学位论文原创性声明和使用授权说明
-\input{data/statement} % 中文声明
-% \input{data/statement_en} % 英文声明
+% \input{data/statement} % 中文声明
+\input{data/statement_en} % 英文声明
 
 % 个人简历、在学期间完成的相关学术成果
 \input{data/resume}

--- a/test/test.sh
+++ b/test/test.sh
@@ -5,17 +5,17 @@ SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 mkdir "$SCRIPT_DIR/../public-test"
 
 # 备份原文件
-cp "$SCRIPT_DIR/../thuthesis-example.tex" "$SCRIPT_DIR/../thuthesis-example.tex.bak"
+cp "$SCRIPT_DIR/../sustechthesis-example.tex" "$SCRIPT_DIR/../sustechthesis-example.tex.bak"
 
 # 生成中文预览
-cp "$SCRIPT_DIR/thuthesis-example-cn.tex" "$SCRIPT_DIR/../thuthesis-example.tex"
+cp "$SCRIPT_DIR/sustechthesis-example-cn.tex" "$SCRIPT_DIR/../sustechthesis-example.tex"
 make
-cp "$SCRIPT_DIR/../thuthesis-example.pdf" "$SCRIPT_DIR/../public-test/thuthesis-example-cn.pdf"
+cp "$SCRIPT_DIR/../sustechthesis-example.pdf" "$SCRIPT_DIR/../public-test/sustechthesis-example-cn.pdf"
 
 # 生成英文预览
-cp "$SCRIPT_DIR/thuthesis-example-en.tex" "$SCRIPT_DIR/../thuthesis-example.tex"
+cp "$SCRIPT_DIR/sustechthesis-example-en.tex" "$SCRIPT_DIR/../sustechthesis-example.tex"
 make
-cp "$SCRIPT_DIR/../thuthesis-example.pdf" "$SCRIPT_DIR/../public-test/thuthesis-example-en.pdf"
+cp "$SCRIPT_DIR/../sustechthesis-example.pdf" "$SCRIPT_DIR/../public-test/sustechthesis-example-en.pdf"
 
 # 恢复源文件
-mv "$SCRIPT_DIR/../thuthesis-example.tex.bak" "$SCRIPT_DIR/../thuthesis-example.tex"
+mv "$SCRIPT_DIR/../sustechthesis-example.tex.bak" "$SCRIPT_DIR/../sustechthesis-example.tex"

--- a/thuthesis.cls
+++ b/thuthesis.cls
@@ -289,6 +289,10 @@
 \thu@package@conflict{unicode-math}{eucal}
 \thu@package@conflict{unicode-math}{eufrak}
 \thu@package@conflict{unicode-math}{mathrsfs}
+% 禁止导入 setspace 包
+\AtBeginOfPackageFile*{setspace}{
+  \thu@error{The "setspace" package is incompatible with table environment, which will make invalidate the float format}
+}
 \geometry{
   paper          = a4paper,  % 210 * 297mm
   marginparwidth = 2cm,
@@ -1658,24 +1662,20 @@
     {\fzxbiaosong \fontsize{24bp}{31.2bp} \textbf{\degree@level 学位论文}}
     \vspace{2cm}
 
-    \begin{spacing}{1.25}
-      {\fontsize{22bp}{28.6bp} \rmfamily \siyuanheiti \thu@title}
-    \end{spacing}
+    % 24 bp*1.3默认行距比例*1.25行距 = 39
+    {\fontsize{24bp}{39bp} \rmfamily \siyuanheiti \thu@title}
     \vspace{1em}
 
-
-    \begin{spacing}{1.25}
-      {\fontsize{22bp}{28.6bp} \textbf{\thu@title@en}}
-    \end{spacing}
+    % 18 bp*1.3默认行距比例*1.25行距 = 29.25
+    {\fontsize{18bp}{29.25bp}\selectfont \textbf{\thu@title@en}}
     \vfill
 
-    \begin{spacing}{1.5}
       {\fontsize{18bp}{23.4bp} \siyuansongti@en \siyuansongti %
+      \renewcommand\arraystretch{1.25}
       \begin{tabular}{@{}r@{：}l@{}}
         \makebox[6em][s]{研究生} & \thu@author\\
         \makebox[6em][s]{指导教师} & \thu@supervisor\\
       \end{tabular}}
-    \end{spacing}
 
     \vspace{2cm}
     {\fontsize{18bp}{23.4bp} \siyuansongti@en \siyuansongti \thu@titlepage@date@sustech}
@@ -1759,8 +1759,8 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
   }%
   \thispagestyle{empty}%
   \begin{center}
-    \begin{spacing}{1.25}
     {\songti \xiaosi
+    \renewcommand\arraystretch{1.25}
     \begin{tabular}{@{}r@{：}l@{}}
       国内图书分类号 & \thu@natclassifiedindex\\
       国际图书分类号 & \thu@intclassifiedindex
@@ -1769,19 +1769,17 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
       学校代码 & \thu@schoolid\\
       密级 & \thu@statesecrets
     \end{tabular}}
-    \end{spacing}
 
     \vspace{3.5cm}
     {\songti \xiaoer \textbf{\thu@subject}}
 
     \vspace{1.5cm}
-    \begin{spacing}{1.25}
-      \erhao \heiti \thu@title
-    \end{spacing}
+    % 24 bp*1.3默认行距比例*1.25行距 = 39
+    {\fontsize{24bp}{39bp}\selectfont \heiti \thu@title}
 
     \vfill
-    \begin{spacing}{1.5}
       {\sihao%
+      \renewcommand\arraystretch{1.5}
       \begin{tabular}{@{}r@{：}l@{}}
         \makebox[6em][s]{\heiti {\degree@level 研究生}} & \thu@author\\
         \makebox[6em][s]{\heiti {指导教师}} & \thu@supervisor\\
@@ -1791,25 +1789,10 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
         \makebox[6em][s]{\heiti {培养单位}} & \thu@department\\
         \makebox[6em][s]{\heiti {学位授予单位}} & 南方科技大学
       \end{tabular}}
-    \end{spacing}
     \vspace{1.5cm}
 
   \end{center}
-  % \null\vskip 0.2cm%
-  % \begingroup
-  %   \centering
-  %   \parbox[t][2cm][t]{\textwidth}{%
-  %     \hskip -0.69cm%
-  %     \thu@titlepage@secret
-  %   }\par
-  %   \vskip 1.5cm%
-  %   {\thu@titlepage@title}%
-  %   \vskip 0.85cm%
-  %   \thu@titlepage@degree
-  %   \vfill
-  %   \parbox[t][7.25cm][t]{\textwidth}{\centering\thu@titlepage@info}\par
-  %   \parbox[t][1.03cm][t]{\textwidth}{\centering\thu@titlepage@date}\par
-  % \endgroup
+
   \clearpage
   \restoregeometry
 }
@@ -1817,8 +1800,8 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 \def\thu@info@item@sustech#1#2{%
   \textbf{#1} & %
   {
-    \linespread{1}\selectfont%
-    \begin{tabular}[t]{@{}l@{}}#2\end{tabular}%
+    \renewcommand\arraystretch{1.15}%
+    \begin{tabular}{@{}l@{}}#2\end{tabular}%
   }
 }%
 
@@ -1829,22 +1812,14 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
     hmargin = 3cm,
   }%
   \thispagestyle{empty}%
-  % \begin{spacing}{1.25}
-    {\xiaosi
-      \noindent
+  {\noindent \xiaosi
+    \renewcommand\arraystretch{1.25}
+    \begin{tabular}{@{}l@{}}
       Classified Index: \thu@natclassifiedindex\\
       U.D.C: \thu@intclassifiedindex
-    }
-  % \end{spacing}
+    \end{tabular}}
 
   \begin{center}
-    % \begin{spacing}{1.25}
-    % {\xiaosi
-
-    %   Classified Index & \thu@natclassifiedindex\\
-    %   U.D.C & \thu@intclassifiedindex
-    % }
-    % \end{spacing}
 
     \vspace{3.5cm}
     \mbox{\xiaoer \thu@subject@en}
@@ -1852,16 +1827,16 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
     \vspace{1.5cm}
     \parbox[t]{30em}{
       \centering
-      \begin{spacing}{1.25}
-        {\erhao \textbf{\thu@title@en}}
-        \end{spacing}
+      % 24 bp*1.15默认行距比例*1.25行距 = 34.5
+      {\fontsize{24bp}{34.5bp}\selectfont \textbf{\thu@title@en}}
       }
     \par
 
     \vfill
-    \begin{spacing}{1.5}
       {\sihao%
-      \begin{tabular}{@{}m{0.44\textwidth}m{0.56\textwidth}@{}}
+      \renewcommand\arraystretch{1.3}
+      % 手动调整使得视觉接近
+      \begin{tabular}{@{}m{0.44\textwidth}m{0.44\textwidth}@{}}
         \thu@info@item@sustech{Candidate:}{\thu@author@en}\\
         \thu@info@item@sustech{Supervisor:}{\thu@supervisor@en}\\
         \thu@info@item@sustech{Academic Degree Applied for:}{\degree@level@en@noun \ of \thu@degree@domain@en}\\
@@ -1870,25 +1845,10 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
         \thu@info@item@sustech{Affiliation:}{\thu@department@en}\\
         \thu@info@item@sustech{Degree-Conferring-Institution:}{Southern University of Science\\and Technology}
       \end{tabular}}
-    \end{spacing}
     \vspace{1.5cm}
 
   \end{center}
-  % \null\vskip 0.2cm%
-  % \begingroup
-  %   \centering
-  %   \parbox[t][2cm][t]{\textwidth}{%
-  %     \hskip -0.69cm%
-  %     \thu@titlepage@secret
-  %   }\par
-  %   \vskip 1.5cm%
-  %   {\thu@titlepage@title}%
-  %   \vskip 0.85cm%
-  %   \thu@titlepage@degree
-  %   \vfill
-  %   \parbox[t][7.25cm][t]{\textwidth}{\centering\thu@titlepage@info}\par
-  %   \parbox[t][1.03cm][t]{\textwidth}{\centering\thu@titlepage@date}\par
-  % \endgroup
+
   \clearpage
   \restoregeometry
 }

--- a/thuthesis.cls
+++ b/thuthesis.cls
@@ -1663,11 +1663,11 @@
     \vspace{2cm}
 
     % 24 bp*1.3默认行距比例*1.25行距 = 39
-    {\fontsize{24bp}{39bp} \rmfamily \siyuanheiti \thu@title}
+    {\fontsize{24bp}{39bp} \rmfamily \siyuanheiti \thu@title \\}
     \vspace{1em}
 
     % 18 bp*1.3默认行距比例*1.25行距 = 29.25
-    {\fontsize{18bp}{29.25bp}\selectfont \textbf{\thu@title@en}}
+    {\fontsize{18bp}{29.25bp}\selectfont \textbf{\thu@title@en \\} }
     \vfill
 
       {\fontsize{18bp}{23.4bp} \siyuansongti@en \siyuansongti %
@@ -1775,7 +1775,7 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 
     \vspace{1.5cm}
     % 24 bp*1.3默认行距比例*1.25行距 = 39
-    {\fontsize{24bp}{39bp}\selectfont \heiti \thu@title}
+    {\fontsize{24bp}{39bp}\selectfont \heiti \thu@title \\}
 
     \vfill
       {\sihao%
@@ -1828,7 +1828,7 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
     \parbox[t]{30em}{
       \centering
       % 24 bp*1.15默认行距比例*1.25行距 = 34.5
-      {\fontsize{24bp}{34.5bp}\selectfont \textbf{\thu@title@en}}
+      {\fontsize{24bp}{34.5bp}\selectfont \textbf{\thu@title@en \\}}
       }
     \par
 

--- a/thuthesis.cls
+++ b/thuthesis.cls
@@ -1155,6 +1155,13 @@
 }
 \captionsetup[sub]{font=thu}
 
+% 研究生要求表单元格中的文字采用 11pt 宋体字，单倍行距。段前空 3 磅，段后空 3 磅。
+% 对于中文，\cs{arraystretch} 需要调整为 $1 + 6 / (11 \times 1.3) \approx 1.42$。
+% 对于英文，\cs{arraystretch} 需要调整为 $1 + 6 / (11 \times 1.15) \approx 1.47$。
+%
+% 注意不能简单地把行距设为 $\SI{11}{pt} \times 1.3 + \SI{6}{pt} = \SI{20.3}{pt}$，
+% 这会导致含有多行文字的单元格中行距有误。
+
 \newcommand\thu@set@table@font{
   \ifthu@language@chinese
     \def\thu@table@font{%

--- a/thuthesis.cls
+++ b/thuthesis.cls
@@ -1469,6 +1469,13 @@
     default = {Title},
     name    = title@en,
   },
+  subtitle = {
+    default = {},
+  },
+  subtitle* = {
+    default = {},
+    name    = subtitle@en,
+  },
   author = {
     default = {姓名},
   },
@@ -1663,11 +1670,23 @@
     \vspace{2cm}
 
     % 24 bp*1.3默认行距比例*1.25行距 = 39
+    % 20 bp*1.3默认行距比例*1.25行距 = 32.5
     {\fontsize{24bp}{39bp} \rmfamily \siyuanheiti \thu@title \\}
+    \ifx\thu@subtitle\empty
+      \relax%
+    \else
+      {\fontsize{20bp}{32.5bp} \rmfamily \siyuanheiti \thu@subtitle \\}
+    \fi
     \vspace{1em}
 
     % 18 bp*1.3默认行距比例*1.25行距 = 29.25
+    % 16 bp*1.3默认行距比例*1.25行距 = 26
     {\fontsize{18bp}{29.25bp}\selectfont \textbf{\thu@title@en \\} }
+    \ifx\thu@subtitle@en\empty
+      \relax%
+    \else
+      {\fontsize{16bp}{26bp}\selectfont \textbf{\thu@subtitle@en \\} }
+    \fi
     \vfill
 
       {\fontsize{18bp}{23.4bp} \siyuansongti@en \siyuansongti %
@@ -1775,7 +1794,13 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 
     \vspace{1.5cm}
     % 24 bp*1.3默认行距比例*1.25行距 = 39
+    % 18 bp*1.3默认行距比例*1.25行距 = 29.25
     {\fontsize{24bp}{39bp}\selectfont \heiti \thu@title \\}
+    \ifx\thu@subtitle\empty
+      \relax%
+    \else
+      {\fontsize{18bp}{29.25bp}\selectfont \heiti \thu@subtitle \\}
+    \fi
 
     \vfill
       {\sihao%
@@ -1828,7 +1853,13 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
     \parbox[t]{30em}{
       \centering
       % 24 bp*1.15默认行距比例*1.25行距 = 34.5
+      % 18 bp*1.15默认行距比例*1.25行距 = 25.875
       {\fontsize{24bp}{34.5bp}\selectfont \textbf{\thu@title@en \\}}
+      \ifx\thu@subtitle@en\empty
+        \relax%
+      \else
+        {\fontsize{18bp}{25.875bp}\selectfont \textbf{\thu@subtitle@en \\}}
+      \fi
       }
     \par
 

--- a/thuthesis.cls
+++ b/thuthesis.cls
@@ -1825,7 +1825,7 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 \def\thu@info@item@sustech#1#2{%
   \textbf{#1} & %
   {
-    \renewcommand\arraystretch{1.15}%
+    \renewcommand\arraystretch{1.15} % 应该只是对可能会换行的英文 item 生效。
     \begin{tabular}{@{}l@{}}#2\end{tabular}%
   }
 }%

--- a/thuthesis.cls
+++ b/thuthesis.cls
@@ -1129,46 +1129,72 @@
 \renewcommand{\topfraction}{0.85}
 \renewcommand{\bottomfraction}{0.65}
 \renewcommand{\floatpagefraction}{0.60}
-\patchcmd\@floatboxreset{%
-  \normalsize
-}{%
-  \fontsize{11bp}{14.3bp}\selectfont
-  \renewcommand\arraystretch{1.4}%
-}{}{\thu@patch@error{\@floatboxreset}}
-\ifthu@degree@bachelor
-  \AtBeginDocument{% delay the check until all packages are loaded
-    \g@addto@macro\appendix{\renewcommand*{\thefigure}{\thechapter-\arabic{figure}}}
-    \g@addto@macro\appendix{\renewcommand*{\thetable}{\thechapter-\arabic{table}}}
-  }
-\fi
-\newcommand\thu@caption@font{}
-\newcommand\thu@set@caption@font{%
+% \ifthu@degree@bachelor
+%   \AtBeginDocument{% delay the check until all packages are loaded
+%     \g@addto@macro\appendix{\renewcommand*{\thefigure}{\thechapter-\arabic{figure}}}
+%     \g@addto@macro\appendix{\renewcommand*{\thetable}{\thechapter-\arabic{table}}}
+%   }
+% \fi
+\DeclareCaptionFont{thu}{%
   \ifthu@degree@bachelor
-    \renewcommand\thu@caption@font{\fontsize{11bp}{15bp}\selectfont}%
+    \fontsize{11bp}{15bp}\selectfont
   \else
-    \renewcommand\thu@caption@font{\fontsize{11bp}{14.3bp}\selectfont}%
+    \ifthu@language@chinese
+      \fontsize{11bp}{14.3bp}\selectfont
+    \else
+      \fontsize{11bp}{12.65bp}\selectfont
+    \fi
   \fi
 }
-\thu@set@caption@font
-\thu@option@hook{degree}{\thu@set@caption@font}
-\DeclareCaptionFont{thu}{\thu@caption@font}
 \captionsetup{
-  format         = hang,
   font           = thu,
   labelsep       = quad,
-  aboveskip      = 6bp,
-  belowskip      = 6bp,
+  skip           = 6bp,
   figureposition = bottom,
   tableposition  = top,
 }
 \captionsetup[sub]{font=thu}
-\renewcommand{\thesubfigure}{(\alph{subfigure})}
-\renewcommand{\thesubtable}{(\alph{subtable})}
+
+\newcommand\thu@set@table@font{
+  \ifthu@language@chinese
+    \def\thu@table@font{%
+      \fontsize{11bp}{14.3bp}\selectfont
+      \renewcommand\arraystretch{1.42}%
+    }%
+  \else
+    \def\thu@table@font{%
+      \fontsize{11bp}{12.65bp}\selectfont
+      \renewcommand\arraystretch{1.47}%
+    }%
+  \fi
+}
+\thu@set@table@font
+\thu@option@hook{language}{\thu@set@table@font}
+\patchcmd\@floatboxreset{%
+  \normalsize
+}{%
+  \thu@table@font
+}{}{\thu@patch@error{\@floatboxreset}}
+
+
+% longtable 同样设定
+\AtEndOfPackageFile*{longtable}{
+  \AtBeginEnvironment{longtable}{%
+    \thu@table@font
+  }
+}
+
+% 三线表线的磅数
 \heavyrulewidth=1.5bp
 \lightrulewidth=1bp
+
 \AtEndOfPackageFile*{threeparttable}{
+  \AtBeginEnvironment{threeparttable}{%
+    \thu@table@font
+  }
   \g@addto@macro\TPT@defaults{\wuhao}
 }
+
 \ifthu@degree@bachelor
   \newcommand{\thu@abstract@name}{中文摘要}
   \newcommand{\thu@abstract@name@en}{Abstract}
@@ -1182,8 +1208,9 @@
   \fi
   %%%%%% 此处为南科大特色格式
   \renewcommand*{\thefigure}{\thechapter-\arabic{figure}}
-  \renewcommand*{\thetable}{\thechapter-\arabic{table}}
   \renewcommand*{\thesubfigure}{\space\alph{subfigure})}
+  \renewcommand*{\thetable}{\thechapter-\arabic{table}}
+  \renewcommand*{\thesubtable}{\space\alph{subtable})}
 \fi
 \ctexset{%
   chapter = {
@@ -3203,12 +3230,6 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
   \let\nomname\thu@denotation@name
   \def\thenomenclature{\begin{denotation}[\nom@tempdim]}
   \def\endthenomenclature{\end{denotation}}
-}
-\AtEndOfPackageFile*{longtable}{
-  \pretocmd\LT@array{%
-    \fontsize{11bp}{14.3bp}\selectfont
-    \renewcommand\arraystretch{1.4}%
-  }{}{\thu@patch@error{\LT@array}}
 }
 \AtEndOfPackageFile*{siunitx}{%
   \sisetup{


### PR DESCRIPTION
修复表格等浮动体内的字体 Fix #18 ，
修复中发现的兼容性问题：不能使用 setspace 宏包，否则会影响 patchcmd 的调整浮动体里面的字体。