### PR TITLE
更新flow，采用最新texlive编译

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
         run: python test/update-dist.py --dev
 
       - name: run texlive docker container
-        uses: docker://texlive/texlive:TL2020-historic
+        uses: docker://texlive/texlive:latest
         # https://hub.docker.com/r/texlive/texlive
         with:
           args: make cleanall doc test clean

--- a/.github/workflows/verify-compile.yml
+++ b/.github/workflows/verify-compile.yml
@@ -17,7 +17,7 @@ jobs:
         run: python test/update-dist.py --dev
 
       - name: run texlive docker container
-        uses: docker://texlive/texlive:TL2020-historic
+        uses: docker://texlive/texlive:latest
         # https://hub.docker.com/r/texlive/texlive
         with:
           args: make doc test

--- a/.github/workflows/verify-compile.yml
+++ b/.github/workflows/verify-compile.yml
@@ -5,6 +5,11 @@ on: [push, pull_request]
 jobs:
   build_latex:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        texlive: [TL2020-historic, latest]
+        # 多版本 TexLive 兼容性测试
+    container: texlive/texlive:${{ matrix.texlive }}
     steps:
       - name: Checkout
         uses: actions/checkout@v2
@@ -17,15 +22,12 @@ jobs:
         run: python test/update-dist.py --dev
 
       - name: run texlive docker container
-        uses: docker://texlive/texlive:latest
-        # https://hub.docker.com/r/texlive/texlive
-        with:
-          args: make doc test
+        run: make doc test
 
       - name: Publish PDF as actions assets
         uses: actions/upload-artifact@v2
         with:
-          name: Example-PDFs
+          name: Example-PDFs-texlive-${{ matrix.texlive }}
           path: |
             sustechthesis.pdf
             public-test/*.pdf

--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -5899,7 +5899,7 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 \RequirePackage{enumitem}
 \RequirePackage{etoolbox}
 \RequirePackage{metalogo}
-\RequirePackage[tightLists=false]{markdown}
+\RequirePackage[tightLists=false,plain]{markdown}
 
 \markdownSetup{
   renderers = {

--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -5899,10 +5899,12 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 \RequirePackage{enumitem}
 \RequirePackage{etoolbox}
 \RequirePackage{metalogo}
-\let\eth\undefined
-\let\digamma\undefined
-\let\backepsilon\undefined
+
+% Pretending the `amssymb` has been loaded.
+% This should be removed after `markdown` v2.13.0.
+\expandafter\def\csname ver@amssymb.sty\endcsname{0000/00/00}
 \RequirePackage[tightLists=false]{markdown}
+\expandafter\let\csname ver@amssymb.sty\endcsname\relax
 
 \markdownSetup{
   renderers = {

--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -5899,7 +5899,10 @@ Thesis for the degree of \degree@level@en@noun \ of \thu@degree@domain@en%
 \RequirePackage{enumitem}
 \RequirePackage{etoolbox}
 \RequirePackage{metalogo}
-\RequirePackage[tightLists=false,plain]{markdown}
+\let\eth\undefined
+\let\digamma\undefined
+\let\backepsilon\undefined
+\RequirePackage[tightLists=false]{markdown}
 
 \markdownSetup{
   renderers = {


### PR DESCRIPTION
- fix #31 ，文档在 texlive2021上的编译错误
  - 上游关联错误：https://github.com/Witiko/markdown/issues/110
- 增加兼容性编译测试
