### PR TITLE
回滚个人简历部分的修改

### DIFF
--- a/data/resume.tex
+++ b/data/resume.tex
@@ -18,37 +18,26 @@
   \section*{在学期间完成的相关学术成果}
   % \section*{Academic Achievements during the Study for an Academic Degree}
 
-  “学术论文”和“申请及已获得的专利”使用 \env{localref} 环境生成，环境内使用 \cs{nocite}\{\texttt{<citekey>}\} 引用参考文献
-  （与 \cs{cite}\{\texttt{<citekey>}\} 使用方式一致）。《指南》要求引用编号连续，故自行计算起始编号作为 \env{localref} 环境参数。“参与的科研项目及获奖情况”使用 \env{achievements} 环境生成，使用方式同 \env{enumerate} 环境，同样需要指定起始编号以满足《指南》要求。\textbf{本段在使用时请删除}。
-
   \subsection{学术论文}
-  % \subsection{Academic papers}
+  % \subsection{Academic Articles}
 
-  % \begin{localref}{参考文献路径}[起始序号（可选）]
-  %   \nocite{引用条目代号} %% 使用方式同 \cite{}
-  % \end{localref}
+  \begin{achievements}
+    \item Yang Y, Ren T L, Zhang L T, et al. Miniature microphone with silicon-based ferroelectric thin films[J]. Integrated Ferroelectrics, 2003, 52:229-235.
+    \item 杨轶, 张宁欣, 任天令, 等. 硅基铁电微声学器件中薄膜残余应力的研究[J]. 中国机械工程, 2005, 16(14):1289-1291.
+    \item 杨轶, 张宁欣, 任天令, 等. 集成铁电器件中的关键工艺研究[J]. 仪器仪表学报, 2003, 24(S4):192-193.
+    \item Yang Y, Ren T L, Zhu Y P, et al. PMUTs for handwriting recognition. In press[J]. (已被Integrated Ferroelectrics录用)
+  \end{achievements}
 
-  \begin{localref}{ref/refs}
-    \nocite{zhangkun1994}
-    \nocite{bixon1996dynamics}
-    \nocite{kamiya2018nature}
-  \end{localref}
-
-
-  \subsection{申请及已获得的专利（无获奖时此项不必列出）}
+  \subsection{申请及已获得的专利（无专利时此项不必列出）}
   % \subsection{Patents}
 
-  % \begin{localref}{参考文献路径}[起始序号（可选）]
-  %   \nocite{引用条目代号} %% 使用方式同 \cite{}
-  % \end{localref}
-
-  \begin{localref}{ref/refs}[4]
-    \nocite{chenxu2020yejing}
-    \nocite{jiangxizhou1980}
-  \end{localref}
+  \begin{achievements}
+    \item 任天令, 杨轶, 朱一平, 等. 硅基铁电微声学传感器畴极化区域控制和电极连接的方法: 中国, CN1602118A[P]. 2005-03-30.
+    \item Ren T L, Yang Y, Zhu Y P, et al. Piezoelectric micro acoustic sensor based on ferroelectric materials: USA, No.11/215, 102[P]. (美国发明专利申请号.)
+  \end{achievements}
 
   \subsection{参与的科研项目及获奖情况（无获奖时此项不必列出）}
-  \begin{achievements}[start=6]
+  \begin{achievements}
     \item 姜锡洲，×××××研究，××省自然科学基金项目。课题编号：××××，长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长长。
     \item ×××，×××××研究，××省自然科学基金项目。课题编号：××××。
     \item ×××，×××××研究，××省自然科学基金项目。课题编号：××××。

--- a/data/resume.tex
+++ b/data/resume.tex
@@ -18,6 +18,8 @@
   \section*{在学期间完成的相关学术成果}
   % \section*{Academic Achievements during the Study for an Academic Degree}
 
+  特别注意，下面的引用文献部分需要使用半角括号，例如[J]，(已被xxxx录用)。(本行在使用时请删除)。
+
   \subsection{学术论文}
   % \subsection{Academic Articles}
 


### PR DESCRIPTION
由于是定制化的国标格式，每个条目后还有括号包含的其他信息。原来方案不太好实现，暂时回滚。

原来引入的 commit e8c88669f23aa89592ee96fd9c41961c0bb9eb8a

<img width="563" alt="image" src="https://user-images.githubusercontent.com/23000702/156536691-c350c9ab-5d56-450a-9da5-d57e61424388.png">
