### PR TITLE
加入 math style 选项

### DIFF
--- a/data/chap03.tex
+++ b/data/chap03.tex
@@ -109,19 +109,24 @@
 
 \section{数学字体}
 
-按照《撰写规范》全文统一采用 Xits Math 或 Cambria Math 中一种字体作为表达式字体即可。
+按照《撰写规范》全文统一采用 Cambria Math （MS Word默认字体）或 Xits Math 中一种字体作为表达式字体即可。
 
 Cambria Math 字体样例：
 
-\thusetup{math-font = cambria}
+\makeatletter
+\thu@load@math@font@cambria
 \begin{equation}
-  f(x)=a_0+ \sum_{n=1}^{\infty}   \left(  a_n\ \cos \frac{n\pi x}{L} +b_n  \sin⁡ \frac{n\pi x}{L}   \right)
+  \frac{1}{2 \uppi \symup{i}} \int_\gamma f = \sum_{k=1}^m n(\gamma; a_k) \mathscr{R}(f; a_k)
+  \label{eq:example}
 \end{equation}
+\makeatother
 
 Xits Math 字体样例：
-\thusetup{math-font = xits}
+\makeatletter
+\thu@load@math@font@xits
 \begin{equation}
-  f(x)=a_0+ \sum_{n=1}^{\infty}   \left(  a_n\ \cos \frac{n\pi x}{L} +b_n  \sin⁡ \frac{n\pi x}{L}   \right)
+  \frac{1}{2 \uppi \symup{i}} \int_\gamma f = \sum_{k=1}^m n(\gamma; a_k) \mathscr{R}(f; a_k)
+  \label{eq:example}
 \end{equation}
-
-\thusetup{math-font = cambria}
+\thu@load@math@font@cambria
+\makeatother

--- a/data/chap03.tex
+++ b/data/chap03.tex
@@ -109,7 +109,7 @@
 
 \section{数学字体}
 
-按照《撰写规范》全文统一采用 Cambria Math （MS Word默认字体）或 Xits Math 中一种字体作为表达式字体即可。
+按照《撰写规范》全文统一采用 Cambria Math （MS Word默认字体）或 Xits Math 中一种字体作为表达式字体即可。Cambria Math 缺少部分样式，例如：积分符号设定为 upright 也看起来没有变化。
 
 Cambria Math 字体样例：
 

--- a/sustech-setup.tex
+++ b/sustech-setup.tex
@@ -88,7 +88,7 @@
   %
   % 数学字体
   % math-style = GB,  % GB （中文默认） | TeX （英文默认）
-  math-font  = cambria,  % （默认，同 Word 默认数学字体一致） ｜ xits （TeX 内常用数学字体）
+  math-font  = cambria,  % cambria （默认，同 Word 默认数学字体一致） ｜ xits （TeX 内常用数学字体）
 }
 
 % 载入所需的宏包

--- a/sustech-setup.tex
+++ b/sustech-setup.tex
@@ -84,6 +84,13 @@
   intclassifiedindex={xx-x},
 }
 
+\thusetup{
+  %
+  % 数学字体
+  % math-style = GB,  % GB （中文默认） | TeX （英文默认）
+  math-font  = cambria,  % （默认，同 Word 默认数学字体一致） ｜ xits （TeX 内常用数学字体）
+}
+
 % 载入所需的宏包
 
 % 可以使用 nomencl 生成符号和缩略语说明

--- a/sustechthesis-example.tex
+++ b/sustechthesis-example.tex
@@ -2,7 +2,7 @@
 % !TeX program = xelatex
 % !TeX spellcheck = en_US
 
-\documentclass[degree=master,language=chinese,cjk-font=external,math-font=cambria]{sustechthesis}
+\documentclass[degree=master,language=chinese,cjk-font=external]{sustechthesis}
   % 学位 degree:
   %   master （默认） | doctor
   % 语言 language:
@@ -12,8 +12,6 @@
   %   在 **非Windows** 的系统上推荐使用包内字体，而非系统字体。
   %   以达到和 Windows 系统上显示的字体效果。
   %   Windows 系统上可以删除该参数，使用系统内置字体。
-  % 数学字体 math-font
-  %   cambria （默认，同 Word 默认数学字体一致） ｜ xits （TeX 内常用数学字体） 等。
 
 
 % 论文基本配置，加载宏包等全局配置

--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -1163,9 +1163,6 @@
     choices = {
       times,
       termes,
-      xits,
-      libertinus,
-      lm,
       auto,
       none,
     },
@@ -1190,8 +1187,6 @@
       cambria,
       xits,
       stix,
-      libertinus,
-      lm,
       none,
     },
     default = cambria,
@@ -1738,19 +1733,8 @@
     \thusetup{math-style=TeX}%
   \fi
 }
-\unimathsetup{
-  math-style = TeX,
-  bold-style = TeX,
-}
-\ifthu@math@style@GB
-  \unimathsetup{
-    math-style = ISO,
-    bold-style = ISO,
-    nabla      = upright,
-    partial    = upright,
-  }
-\fi
 \newcommand\thu@xits@integral@stylistic@set{%
+  %\ifthu@language@english
   \ifthu@math@style@GB
     8%upright
   \fi
@@ -1789,11 +1773,6 @@
 \newcommand\thu@load@math@font@cambria{%
   \setmathfont[Path = "fonts/"]{CambriaMath.otf}%
 }
-\newcommand\thu@load@math@font{%
-  \@nameuse{thu@load@math@font@\thu@math@font}
-}
-\thu@load@math@font
-\thu@option@hook{math-font}{\thu@load@math@font}
 %    \end{macrocode}
 %
 % 中文字体
@@ -2490,16 +2469,16 @@
 % 省略号一律居中，所以 \cs{ldots} 不再居于底部。
 %    \begin{macrocode}
 \newcommand\thu@set@math@ellipsis{%
-  \ifthu@math@style@GB
-    \DeclareRobustCommand\mathellipsis{\mathinner{\unicodecdots}}%
-  \else
-    \ifthu@math@style@TeX
-      \DeclareRobustCommand\mathellipsis{\mathinner{\unicodeellipsis}}%
+  \AtBeginDocument{%
+    \ifthu@math@style@GB
+      \DeclareRobustCommand\mathellipsis{\mathinner{\unicodecdots}}%
+    \else
+      \ifthu@math@style@TeX
+        \DeclareRobustCommand\mathellipsis{\mathinner{\unicodeellipsis}}%
+      \fi
     \fi
-  \fi
+  }
 }
-\thu@set@math@ellipsis
-\thu@option@hook{language}{\thu@set@math@ellipsis}
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2509,14 +2488,16 @@
 % \begin{macro}{\geq}
 % 小于等于号要使用倾斜的形式，仅中文生效。
 %    \begin{macrocode}
-\ifthu@math@style@GB
-  \protected\def\le{\leqslant}
-  \protected\def\ge{\geqslant}
+\newcommand\thu@set@math@leq{%
   \AtBeginDocument{%
-    \renewcommand\leq{\leqslant}%
-    \renewcommand\geq{\geqslant}%
+    \ifthu@math@style@GB
+      \protected\def\le{\leqslant}
+      \protected\def\ge{\geqslant}
+      \renewcommand\leq{\leqslant}%
+      \renewcommand\geq{\geqslant}%
+    \fi
   }
-\fi
+}
 %    \end{macrocode}
 % \end{macro}
 % \end{macro}
@@ -2526,25 +2507,30 @@
 % \begin{macro}{\int}
 % 积分号 \cs{int} 使用正体，并且上下限默认置于积分号上下两侧。
 %    \begin{macrocode}
-\ifthu@math@style@GB
-  \removenolimits{%
-    \int\iint\iiint\iiiint\oint\oiint\oiiint
-    \intclockwise\varointclockwise\ointctrclockwise\sumint
-    \intbar\intBar\fint\cirfnint\awint\rppolint
-    \scpolint\npolint\pointint\sqint\intlarhk\intx
-    \intcap\intcup\upint\lowint
-  }%
-\else
-  \ifthu@math@style@TeX
-    \addnolimits{%
-      \int\iint\iiint\iiiint\oint\oiint\oiiint
-      \intclockwise\varointclockwise\ointctrclockwise\sumint
-      \intbar\intBar\fint\cirfnint\awint\rppolint
-      \scpolint\npolint\pointint\sqint\intlarhk\intx
-      \intcap\intcup\upint\lowint
-    }%
-  \fi
-\fi
+\newcommand\thu@set@unimath@integral@limits{
+  \AtBeginDocument{%
+    \ifthu@math@style@GB
+      \removenolimits{%
+        \int\iint\iiint\iiiint\oint\oiint\oiiint
+        \intclockwise\varointclockwise\ointctrclockwise\sumint
+        \intbar\intBar\fint\cirfnint\awint\rppolint
+        \scpolint\npolint\pointint\sqint\intlarhk\intx
+        \intcap\intcup\upint\lowint
+      }%
+    \else
+      \ifthu@math@style@TeX
+        \addnolimits{%
+          \int\iint\iiint\iiiint\oint\oiint\oiiint
+          \intclockwise\varointclockwise\ointctrclockwise\sumint
+          \intbar\intBar\fint\cirfnint\awint\rppolint
+          \scpolint\npolint\pointint\sqint\intlarhk\intx
+          \intcap\intcup\upint\lowint
+        }%
+      \fi
+    \fi
+  }
+}
+
 %    \end{macrocode}
 % \end{macro}
 %
@@ -2553,11 +2539,13 @@
 % 实部、虚部操作符使用罗马体 $\mathrm{Re}$、$\mathrm{Im}$ 而不是 fraktur 体
 % $\Re$、$\Im$。
 %    \begin{macrocode}
-\AtBeginDocument{%
-  \ifthu@math@style@GB
-    \renewcommand{\Re}{\operatorname{Re}}%
-    \renewcommand{\Im}{\operatorname{Im}}%
-  \fi
+\newcommand\thu@set@unimath@real@part{%
+  \AtBeginDocument{%
+    \ifthu@math@style@GB
+      \renewcommand{\Re}{\operatorname{Re}}%
+      \renewcommand{\Im}{\operatorname{Im}}%
+    \fi
+  }
 }
 %    \end{macrocode}
 % \end{macro}
@@ -2566,13 +2554,45 @@
 % \begin{macro}{\nabla}
 % \cs{nabla} 使用粗正体。
 %    \begin{macrocode}
-\AtBeginDocument{%
-  \ifthu@math@style@GB
-    \renewcommand\nabla{\mbfnabla}%
-  \fi
+\newcommand\thu@set@unimath@nabla{
+  \AtBeginDocument{%
+    \ifthu@math@style@GB
+      \renewcommand\nabla{\mbfnabla}%
+    \fi
+  }
 }
 %    \end{macrocode}
 % \end{macro}
+%
+%    \begin{macrocode}
+\newcommand\thu@set@unimath@style{%
+  \thu@set@math@ellipsis
+  \thu@set@math@leq
+  \thu@set@unimath@integral@limits
+  \thu@set@unimath@real@part
+  \thu@set@unimath@nabla
+}
+\newcommand\thu@load@math@font{%
+  \AtBeginDocument{%
+    \unimathsetup{
+      math-style = TeX,
+      bold-style = TeX,
+    }
+    \ifthu@math@style@GB
+      \unimathsetup{
+        math-style = ISO,
+        bold-style = ISO,
+        nabla      = upright,
+        partial    = upright,
+      }
+    \fi
+    \@nameuse{thu@load@math@font@\thu@math@font}
+  }
+  \thu@set@unimath@style
+}
+\thu@load@math@font
+\thu@option@hook{math-font}{\thu@load@math@font}
+%    \end{macrocode}
 %
 % \begin{macro}{\bm}
 % \begin{macro}{\boldsymbol}

--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -689,10 +689,10 @@
 %
 % \DescribeOption{math-style}
 % 用户可以通过设置 \option{math-style} 选择数学符号样式（可选：
-% \option{GB}（中文默认），\option{TeX}（英文默认）和 \option{ISO}），比如：
+% \option{GB}（中文默认），\option{TeX}（英文默认）），比如：
 % \begin{latex}
 %   \thusetup{
-%     math-style = ISO,
+%     math-style = GB,
 %   }
 % \end{latex}
 %
@@ -1195,7 +1195,6 @@
     name = math@style,
     choices = {
       GB,
-      ISO,
       TeX,
     },
   },

--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -687,6 +687,15 @@
 %   \item 微分号和积分号使用使用正体，比如 $\int f(x) \dif x$。
 % \end{enumerate}
 %
+% \DescribeOption{math-style}
+% 用户可以通过设置 \option{math-style} 选择数学符号样式（可选：
+% \option{GB}（中文默认），\option{TeX}（英文默认）和 \option{ISO}），比如：
+% \begin{latex}
+%   \thusetup{
+%     math-style = ISO,
+%   }
+% \end{latex}
+%
 % 关于数学符号更多的用法，参考
 % \href{http://mirrors.ctan.org/macros/latex/contrib/unicode-math/unicode-math.pdf}{\pkg{unicode-math}}
 % 宏包的使用说明，
@@ -1186,6 +1195,14 @@
       none,
     },
     default = cambria,
+  },
+  math-style = {
+    name = math@style,
+    choices = {
+      GB,
+      ISO,
+      TeX,
+    },
   },
 %    \end{macrocode}
 %
@@ -1709,11 +1726,23 @@
 %
 % 使用 \pkg{unicode-math} 配置数学字体
 %    \begin{macrocode}
+\ifthu@language@chinese
+  \thusetup{math-style=GB}%
+\else
+  \thusetup{math-style=TeX}%
+\fi
+\thu@option@hook{language}{%
+  \ifthu@language@chinese
+    \thusetup{math-style=GB}%
+  \else
+    \thusetup{math-style=TeX}%
+  \fi
+}
 \unimathsetup{
   math-style = TeX,
   bold-style = TeX,
 }
-\ifthu@language@chinese
+\ifthu@math@style@GB
   \unimathsetup{
     math-style = ISO,
     bold-style = ISO,
@@ -1722,7 +1751,7 @@
   }
 \fi
 \newcommand\thu@xits@integral@stylistic@set{%
-  \ifthu@language@chinese
+  \ifthu@math@style@GB
     8%upright
   \fi
 }
@@ -2461,10 +2490,10 @@
 % 省略号一律居中，所以 \cs{ldots} 不再居于底部。
 %    \begin{macrocode}
 \newcommand\thu@set@math@ellipsis{%
-  \ifthu@language@chinese
+  \ifthu@math@style@GB
     \DeclareRobustCommand\mathellipsis{\mathinner{\unicodecdots}}%
   \else
-    \ifthu@language@english
+    \ifthu@math@style@TeX
       \DeclareRobustCommand\mathellipsis{\mathinner{\unicodeellipsis}}%
     \fi
   \fi
@@ -2480,7 +2509,7 @@
 % \begin{macro}{\geq}
 % 小于等于号要使用倾斜的形式，仅中文生效。
 %    \begin{macrocode}
-\ifthu@language@chinese
+\ifthu@math@style@GB
   \protected\def\le{\leqslant}
   \protected\def\ge{\geqslant}
   \AtBeginDocument{%
@@ -2497,7 +2526,7 @@
 % \begin{macro}{\int}
 % 积分号 \cs{int} 使用正体，并且上下限默认置于积分号上下两侧。
 %    \begin{macrocode}
-\ifthu@language@chinese
+\ifthu@math@style@GB
   \removenolimits{%
     \int\iint\iiint\iiiint\oint\oiint\oiiint
     \intclockwise\varointclockwise\ointctrclockwise\sumint
@@ -2506,13 +2535,15 @@
     \intcap\intcup\upint\lowint
   }%
 \else
-  \addnolimits{%
-    \int\iint\iiint\iiiint\oint\oiint\oiiint
-    \intclockwise\varointclockwise\ointctrclockwise\sumint
-    \intbar\intBar\fint\cirfnint\awint\rppolint
-    \scpolint\npolint\pointint\sqint\intlarhk\intx
-    \intcap\intcup\upint\lowint
-  }%
+  \ifthu@math@style@TeX
+    \addnolimits{%
+      \int\iint\iiint\iiiint\oint\oiint\oiiint
+      \intclockwise\varointclockwise\ointctrclockwise\sumint
+      \intbar\intBar\fint\cirfnint\awint\rppolint
+      \scpolint\npolint\pointint\sqint\intlarhk\intx
+      \intcap\intcup\upint\lowint
+    }%
+  \fi
 \fi
 %    \end{macrocode}
 % \end{macro}
@@ -2523,7 +2554,7 @@
 % $\Re$、$\Im$。
 %    \begin{macrocode}
 \AtBeginDocument{%
-  \ifthu@language@chinese
+  \ifthu@math@style@GB
     \renewcommand{\Re}{\operatorname{Re}}%
     \renewcommand{\Im}{\operatorname{Im}}%
   \fi
@@ -2536,7 +2567,7 @@
 % \cs{nabla} 使用粗正体。
 %    \begin{macrocode}
 \AtBeginDocument{%
-  \ifthu@language@chinese
+  \ifthu@math@style@GB
     \renewcommand\nabla{\mbfnabla}%
   \fi
 }


### PR DESCRIPTION
加入 math style 选项，方便在英文模式下也能用中文的数学设定。
**注意：cambria 字体不支持积分符号的正体与斜体，需要用 xits 调试。** ~~排除这个bug用了好久~~