### PR TITLE
模拟word的字间距

### DIFF
--- a/sustechthesis.dtx
+++ b/sustechthesis.dtx
@@ -1487,6 +1487,9 @@
 \renewcommand\mainmatter{%
   \cleardoublepage
   \@mainmattertrue
+  \ifthu@language@chinese
+    \ziju{0.12}% 调整中文字距，使得每行字数更像Word。
+  \fi
   \pagenumbering{arabic}%
 }
 \renewcommand\backmatter{%
@@ -1494,6 +1497,9 @@
     \cleardoublepage
   \else
     \clearpage
+  \fi
+  \ifthu@language@chinese
+    \ziju{0}
   \fi
   \@mainmatterfalse
   \thusetup{toc-depth = 0}%


### PR DESCRIPTION
word的字间距看起来会比latex大。所以latex每页的字数会多。

还有由于word的两端对齐的效果难以在latex中模拟。特别是以下现象
<img width="562" alt="image" src="https://user-images.githubusercontent.com/23000702/162105686-c130ca44-13ea-4a18-bf7c-8fc74c90f087.png">
字间距不是等距拉伸。

并且《撰写规范》中并无定义每页有多少行和字间距，仅定义了页面边距，行间距，段前后距离。

这里先留个PR待讨论。